### PR TITLE
adding includes

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -2,6 +2,7 @@
 #define CONSTANTS_HPP
 
 #include <array>
+#include <cstdint>
 #include <type_traits>
 
 namespace constants {

--- a/include/external_memory_vector.hpp
+++ b/include/external_memory_vector.hpp
@@ -7,6 +7,7 @@
 #ifndef EXTERNAL_MEMORY_VECTOR
 #define EXTERNAL_MEMORY_VECTOR
 
+#include <algorithm>
 #include <functional>
 #include <vector>
 #include <string>

--- a/include/io.hpp
+++ b/include/io.hpp
@@ -2,6 +2,8 @@
 #define IO_HPP
 
 #include <string>
+#include <cstring>
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <fstream>


### PR DESCRIPTION
While building [kaminari](https://github.com/yhhshb/kaminari) with biolib as an external project, `make` fails because of some missing libraries.
I'm using
``` bash
$ gcc --version
gcc (conda-forge gcc 14.1.0-0) 14.1.0
```